### PR TITLE
feat: enhance support for duration with a 2 stats line layout

### DIFF
--- a/pretty_gpx/rendering_modes/city/city_vertical_layout.py
+++ b/pretty_gpx/rendering_modes/city/city_vertical_layout.py
@@ -16,3 +16,11 @@ class CityVerticalLayout(ElevationVerticalLayout):
                                   map_relative_h=0.65,
                                   elevation_relative_h=0.05,
                                   stats_relative_h=0.12)
+
+    @staticmethod
+    def two_lines_stats() -> 'CityVerticalLayout':
+        """Return the default City Vertical Layout with a bigger stat height to have 2 lines."""
+        return CityVerticalLayout(title_relative_h=0.18,
+                                  map_relative_h=0.57,
+                                  elevation_relative_h=0.05,
+                                  stats_relative_h=0.20)

--- a/pretty_gpx/rendering_modes/city/wip_city_sample.py
+++ b/pretty_gpx/rendering_modes/city/wip_city_sample.py
@@ -38,7 +38,10 @@ from pretty_gpx.rendering_modes.city.drawing.theme_colors import ThemeColors
 def plot(gpx_track: GpxTrack, theme_colors: ThemeColors) -> None:
     """Plot a GPX track on a city map."""
     paper = PAPER_SIZES['A4']
-    layout = CityVerticalLayout.default()
+    if gpx_track.duration_s is not None:
+        layout = CityVerticalLayout.two_lines_stats()
+    else:
+        layout = CityVerticalLayout.default()
     roads_bounds, base_plotter = layout.get_download_bounds_and_paper_figure(gpx_track, paper)
 
     caracteristic_distance_m = (roads_bounds.dx_m**2 + roads_bounds.dy_m**2)**0.5


### PR DESCRIPTION
## Description

With the new elevation profile in city mode, when there were duration in the gpx the text did not fit to the designated area.
Now 2 layouts are possible : the default one and another one with a larger stat height

## Proof of Functionality

![R4C](https://github.com/user-attachments/assets/cff33f88-14d7-4f24-a138-47204309281e)
