### PR TITLE
fix: handle case when user gives float instead of int

### DIFF
--- a/pretty_gpx/rendering_modes/city/city_poster_image_cache.py
+++ b/pretty_gpx/rendering_modes/city/city_poster_image_cache.py
@@ -91,8 +91,8 @@ class CityPosterImageCache:
                             duration_s: str,
                             dist_km: str) -> CityPosterDrawingData:
         """Update the drawing data (can run in a separate thread)."""
-        dist_km_int = int(dist_km if dist_km != '' else self.stats_dist_km)
-        uphill_m_int = int(uphill_m if uphill_m != '' else self.stats_uphill_m)
+        dist_km_int = int(float(dist_km if dist_km != '' else self.stats_dist_km))
+        uphill_m_int = int(float(uphill_m if uphill_m != '' else self.stats_uphill_m))
         stats_duration_s = float(duration_s) if duration_s != '' else self.stats_duration_s
         stats_text = f"{dist_km_int} km - {uphill_m_int} m D+"
 

--- a/pretty_gpx/rendering_modes/mountain/drawing/mountain_poster_image_cache.py
+++ b/pretty_gpx/rendering_modes/mountain/drawing/mountain_poster_image_cache.py
@@ -147,8 +147,8 @@ class MountainPosterImageCache:
 
         img = colored_hillshade.astype(np.uint8)
 
-        dist_km_int = int(dist_km if dist_km != '' else self.stats_dist_km)
-        uphill_m_int = int(uphill_m if uphill_m != '' else self.stats_uphill_m)
+        dist_km_int = int(float(dist_km if dist_km != '' else self.stats_dist_km))
+        uphill_m_int = int(float(uphill_m if uphill_m != '' else self.stats_uphill_m))
         stats_text = f"{dist_km_int} km - {uphill_m_int} m D+"
 
         return MountainPosterDrawingData(img, theme_colors, title_txt=title_txt, stats_text=stats_text)


### PR DESCRIPTION
## Description

If the user passes a float instead of an int for uphill or km in the gui, it would raise an error because:
int("10.5") is not possible, but as int(10.5) is possible, it is possible to prevent this error by casting to float before casting to int 