### PR TITLE
perf: Use agg backend mode

### DIFF
--- a/pretty_gpx/rendering_modes/city/drawing/city_drawer.py
+++ b/pretty_gpx/rendering_modes/city/drawing/city_drawer.py
@@ -121,6 +121,7 @@ class CityDrawer(Drawer[CityAugmentedGpxData,
                           plotter=plotter,
                           gpx_data=gpx_data)
 
+    @profile
     def get_params(self, inputs: CityDrawingInputs) -> CityDrawingParams:
         """Convert DrawingInputs to DrawingParams."""
         dist_km_int = inputs.dist_km if inputs.dist_km is not None else self.stats_dist_km

--- a/pretty_gpx/rendering_modes/mountain/drawing/mountain_drawer.py
+++ b/pretty_gpx/rendering_modes/mountain/drawing/mountain_drawer.py
@@ -100,6 +100,7 @@ class MountainDrawer(Drawer[MountainAugmentedGpxData,
                               plotter=plotter,
                               gpx_data=gpx_data)
 
+    @profile
     def get_params(self, inputs: MountainDrawingInputs) -> MountainDrawingParams:
         """Convert DrawingInputs to DrawingParams."""
         if inputs.high_res:


### PR DESCRIPTION
## Description
Use agg backend mode when drawing PNG or SVG for faster subplots creation
plt.subplots() : 110ms -> 9ms

## Corresponding Github Issues / Pull Requests

## Proof of Functionality
*Provide evidence that the changes work as intended. Include screenshots, logs, or other relevant output.*

## Warning