### PR TITLE
perf: Simplify roads to reduce vectorized image size

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -18,5 +18,5 @@ ruff==0.4.6
 textalloc==1.1.3
 shapely==2.0.6
 types-shapely==2.0.0.20240820
-ujson==5.10.0
-types-ujson==5.10.0.20240515
+orjson==3.10.7
+requests==2.32.3

--- a/.vscode/.mypy.ini
+++ b/.vscode/.mypy.ini
@@ -44,3 +44,9 @@ ignore_missing_imports = True
 
 [mypy-overpy.*]
 ignore_missing_imports = True
+
+[mypy-requests.*]
+ignore_missing_imports = True
+
+[mypy-orjson.*]
+ignore_missing_imports = True

--- a/pretty_gpx/common/data/overpass_request.py
+++ b/pretty_gpx/common/data/overpass_request.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from dataclasses import field
 from io import BytesIO
 from typing import Any
-from typing import TypeVar
 
 import orjson
 import requests
@@ -170,8 +169,6 @@ class OverpassQuery:
         return self.query_unprocessed_results[array_name]
 
 
-T = TypeVar('T')
-
 @profile
 def download_query(query: str) -> dict[str, Any]:
     """Download the query from Overpass API."""
@@ -202,4 +199,3 @@ def download_query(query: str) -> dict[str, Any]:
         data = orjson.loads(content_bytes.getvalue())
 
     return data
-

--- a/pretty_gpx/common/utils/utils.py
+++ b/pretty_gpx/common/utils/utils.py
@@ -5,6 +5,7 @@ import os
 from typing import TypeVar
 
 EARTH_RADIUS_M = 6371000
+MAX_RECURSION_DEPTH = 100 #sys.getrecursionlimit() - 10
 
 T = TypeVar('T')
 

--- a/pretty_gpx/fly/fly_io_setup.py
+++ b/pretty_gpx/fly/fly_io_setup.py
@@ -83,6 +83,6 @@ def fly_io_setup() -> bool:
     app.config.socket_io_js_query_params['fly_instance_id'] = fly_instance_id  # for websocket (FlyReplayMiddleware)
 
     import dns.resolver  # NOTE only import on fly where we have it installed to look up if instance is still available
-    app.add_middleware(FlyReplayMiddleware)
+    app.add_middleware(FlyReplayMiddleware)  # type: ignore
 
     return True


### PR DESCRIPTION
## Description

To reduce the size of the svg two features have been developped

* Simplify each line with shapely Douglas-Peucker algorithm.
* Get the ways count for each precision level and chose a precision level based on a criteria (criteria might need to be enhanced with more usage but for now it does perform good) -> implemented in https://github.com/ThomasParistech/pretty-gpx/pull/65

-> The Paris Marathon filesize drops from 25Mb to 11Mb

## Corresponding Github Issues / Pull Requests

https://github.com/ThomasParistech/pretty-gpx/issues/59