### PR TITLE
fix: overpass queries and bridges

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ This feature utilizes [OpenStreetMap data](https://www.openstreetmap.org) via th
 The distance, elevation gain and time of the activity plotted is written on the poster by default. If you want to remove one of these fields, just enter a 0 or negative value.
 If you want to override the time, you will need to enter the time **in seconds** that you want to have written on the poster.
 
+### Bridges detection
+
+The system automatically identifies bridges crossed by your path. It does this by approximating each bridge as a rectangular area and using two criteria:
+
+- **Intersection Length**: If the length of the path's intersection with the rectangular area exceeds 70% of the bridge's length, the bridge is considered crossed.
+- **Angle Threshold**: The angle between the path and the bridge's axis must be below a certain threshold to ensure that only bridges directly crossed are detected, avoiding false positives.
+
+
 ### ⛶ Poster Size
 
 You have the same options as the mountain mode for the paper sizes. It is possible to find the most suitable format for your activity.

--- a/pretty_gpx/common/request/osm_name.py
+++ b/pretty_gpx/common/request/osm_name.py
@@ -73,6 +73,11 @@ def get_shortest_name(nwr: Node | Way | Relation) -> str | None:
     if alt_names is not None:
         possible_names.extend(str(alt_names).split(";"))
 
+    bridge_name = tags.get("bridge:name", None)
+    if bridge_name is not None:
+        #This one forces to get the real bridge name and not the street name
+        return bridge_name
+
     if len(possible_names) == 0:
         return None
 

--- a/pretty_gpx/common/request/overpass_request.py
+++ b/pretty_gpx/common/request/overpass_request.py
@@ -106,8 +106,8 @@ class OverpassQuery:
         query = f"""
 (
 {query_body}
-{reccursion}
 )->.all_items_{array_name};
+(.all_items_{array_name}; {reccursion})->.all_items_{array_name};
 .all_items_{array_name} out geom;"""
 
         self.query_dict[array_name] = query

--- a/pretty_gpx/common/utils/utils.py
+++ b/pretty_gpx/common/utils/utils.py
@@ -2,9 +2,10 @@
 """Utils."""
 
 import os
+from typing import TypeVar
+
 import numpy as np
 from shapely import LineString
-from typing import TypeVar
 
 EARTH_RADIUS_M = 6371000
 MAX_RECURSION_DEPTH = 100  # sys.getrecursionlimit() - 10

--- a/pretty_gpx/common/utils/utils.py
+++ b/pretty_gpx/common/utils/utils.py
@@ -2,6 +2,8 @@
 """Utils."""
 
 import os
+import numpy as np
+from shapely import LineString
 from typing import TypeVar
 
 EARTH_RADIUS_M = 6371000
@@ -113,3 +115,11 @@ def convert_bytes(size_bytes: int) -> str:
 def snake_case_to_label(content: str) -> str:
     """Convert Snake Case String to Label. (hello_world -> Hello World)."""
     return ' '.join([word.title() for word in content.split("_")])
+
+def get_average_straight_line(x_coords: list[float], y_coords: list[float]) -> tuple[LineString, tuple[float, float]]:
+    """Get a 2 points line representation of a line."""
+    p = np.polynomial.Polynomial.fit(x_coords, y_coords, deg=1).convert()
+    direction_vector = (1., p.coef[1])
+    x_min, x_max = min(x_coords), max(x_coords)
+    bridge_2_points = LineString([(x_min, p(x_min)), (x_max, p(x_max))])
+    return bridge_2_points, direction_vector

--- a/pretty_gpx/rendering_modes/city/data/bridges.py
+++ b/pretty_gpx/rendering_modes/city/data/bridges.py
@@ -33,10 +33,8 @@ from pretty_gpx.common.utils.utils import EARTH_RADIUS_M
 from pretty_gpx.common.utils.utils import get_average_straight_line
 
 BRIDGES_CACHE = GpxDataCacheHandler(name='bridges', extension='.pkl')
-
 BRIDGES_RELATIONS_ARRAY_NAME = "bridges_relations"
 BRIDGES_WAYS_ARRAY_NAME = "bridges_ways"
-
 
 @dataclass
 class Bridge:
@@ -47,7 +45,6 @@ class Bridge:
     aspect_ratio: float
     center: Point
     direction: tuple[float, float] | None
-
 
 class BridgeApproximation:
     """Bridge rectangle approximation."""
@@ -82,20 +79,17 @@ class BridgeApproximation:
                   LineString([coords[i], coords[(i + 1) % 4]])) for i in range(4)]
         sides.sort(key=lambda x: float(x[0]), reverse=True)
         longest_length, shortest_length = float(sides[0][0]), float(sides[3][0])
-        aspect_ratio = shortest_length / longest_length
-
         if (sides[0][0] + sides[1][0])/2.0 < min_length:
             logger.warning("Bridge has not minimum length")
             return None, 0., 0.
 
+        aspect_ratio = shortest_length / longest_length
         if aspect_ratio >= min_aspect_ratio:
             return rectangle, aspect_ratio, longest_length
 
         p1, p2 = sides[2][1].interpolate(0.5, normalized=True), sides[3][1].interpolate(0.5, normalized=True)
-        median_line = LineString([p1, p2])
         buffer_size = float(longest_length * min_aspect_ratio) / 2.
-
-        return ShapelyPolygon(median_line.buffer(buffer_size)), min_aspect_ratio, longest_length
+        return ShapelyPolygon(LineString([p1, p2]).buffer(buffer_size)), min_aspect_ratio, longest_length
 
     @classmethod
     def create_bridge(cls,
@@ -105,40 +99,34 @@ class BridgeApproximation:
         try:
             if isinstance(way_or_relation, Way):
                 bridge_coords = get_way_coordinates(way_or_relation)
-            elif isinstance(way_or_relation, Relation) and way_or_relation.members is not None:
-                outer_members = [
-                    member.geometry for member in way_or_relation.members
-                    if type(member) == RelationWay and member.geometry is not None and member.role == "outer"]
-
+            elif isinstance(way_or_relation, Relation) and way_or_relation.members:
+                outer_members = [member.geometry for member in way_or_relation.members
+                               if isinstance(member, RelationWay) and member.geometry 
+                               and member.role == "outer"]
                 merged_ways = merge_ways(outer_members)
                 if len(merged_ways) > 1:
                     logger.error("Multiple geometries found")
                     return None
                 bridge_coords = get_lat_lon_from_geometry(merged_ways[0])
             else:
-                raise TypeError   
+                raise TypeError
 
             bridge_polygon = ShapelyPolygon(bridge_coords)
             bridge_simplified, aspect_ratio, bridge_length = cls.get_minimum_rectangle(bridge_polygon)
             bridge_name = get_shortest_name(way_or_relation)
+            bridge_dir = None
 
-            if (bridge_name is not None and bridges_stats.get(bridge_name, False) 
-                and bridges_stats[bridge_name][1] > 0.25*bridge_length):
+            if bridge_name and bridge_name in bridges_stats:
                 bridge_dir, bridge_length = bridges_stats[bridge_name]
             else:
-                bridge_dir = None
-                logger.warning(f"Could not find direction of the bridge {bridge_name}")
+                logger.warning(f"Could not find direction of bridge {bridge_name}")
 
-            if not bridge_simplified or aspect_ratio > cls.MAXIMUM_BRIDGE_ASPECT_RATIO and bridge_dir is None:
+            if not bridge_simplified or (aspect_ratio > cls.MAXIMUM_BRIDGE_ASPECT_RATIO and bridge_dir is None):
                 logger.warning(f"Skipped bridge {bridge_name}: invalid aspect ratio or length.")
                 return None
 
-            return Bridge(name=bridge_name,
-                          polygon=bridge_simplified,
-                          length=bridge_length,
-                          aspect_ratio=aspect_ratio,
-                          center=bridge_polygon.centroid,
-                          direction=bridge_dir)
+            return Bridge(name=bridge_name, polygon=bridge_simplified, length=bridge_length,
+                      aspect_ratio=aspect_ratio, center=bridge_polygon.centroid, direction=bridge_dir)
         except Exception as e:
             logger.error(f"Error processing bridge: {e}")
             return None
@@ -149,7 +137,36 @@ class BridgeCrossingAnalyzer:
     ANGLE_THRESHOLD = 20
 
     @staticmethod
-    def analyze_track_bridge_crossing(track: GpxTrack, bridges: list[Bridge]) -> list[Bridge]:
+    def _calculate_intersection_length(intersection: BaseGeometry) -> float:
+        """Calculate the length of intersection between track and bridge."""
+        if isinstance(intersection, GeometryCollection | MultiLineString):
+            return sum(geom.length for geom in intersection.geoms if isinstance(geom, LineString))
+        return intersection.length if isinstance(intersection, LineString) else 0
+
+    @staticmethod
+    def _extract_intersection_coordinates(intersection: BaseGeometry) -> tuple[list[float], list[float]] | None:
+        """Extract x,y coordinates from intersection geometry."""
+        if isinstance(intersection, GeometryCollection | MultiLineString):
+            coords = [(x, y) for geom in intersection.geoms 
+                     if isinstance(geom, LineString) for x, y in geom.coords]
+            if not coords:
+                return None
+            x_coords, y_coords = zip(*coords)
+            return list(x_coords), list(y_coords)
+        elif isinstance(intersection, LineString):
+            return list(intersection.xy[0]), list(intersection.xy[1])
+        return None
+
+    @staticmethod
+    def _calculate_crossing_angle(dir1: tuple[float, float], dir2: tuple[float, float]) -> float:
+        """Calculate the angle between two direction vectors."""
+        cos_angle = np.clip(
+            np.dot(dir1, dir2) / (np.linalg.norm(dir1) * np.linalg.norm(dir2)), -1, 1)
+        angle = np.degrees(np.arccos(cos_angle))
+        return min(angle, 180-angle)
+
+    @classmethod
+    def analyze_track_bridge_crossing(cls, track: GpxTrack, bridges: list[Bridge]) -> list[Bridge]:
         """Returns bridges significantly crossed by the track."""
         crossed_bridges = []
         shapely_track = LineString(zip(track.list_lon, track.list_lat))
@@ -159,67 +176,52 @@ class BridgeCrossingAnalyzer:
             if intersection.is_empty:
                 continue
 
-            intersection_length = BridgeCrossingAnalyzer._calculate_length(intersection)
-            if intersection_length <= BridgeCrossingAnalyzer.INTERSECTION_THRESHOLD * bridge.length:
-                logger.warning(f"Length too small {bridge.name}")
-                continue  # Skip if intersection is too small
+            intersection_length = cls._calculate_intersection_length(intersection)
+            if intersection_length <= cls.INTERSECTION_THRESHOLD * bridge.length:
+                logger.debug(f"Length of intersection is too small {bridge.name}")
+                continue
 
             if bridge.direction is None:
-                logger.info(f"{bridge.name} crossed")
+                logger.debug(f"{bridge.name} crossed")
                 crossed_bridges.append(bridge)
                 continue
 
-            intersection_direction = BridgeCrossingAnalyzer._get_median_line(intersection)
-            angle = np.degrees(
-                np.arccos(np.clip(np.dot(intersection_direction, bridge.direction) /
-                                  (np.linalg.norm(intersection_direction) * np.linalg.norm(bridge.direction)), -1, 1))
-            )
-            if min(angle, 180-angle) < BridgeCrossingAnalyzer.ANGLE_THRESHOLD:
-                logger.info(f"{bridge.name} crossed {angle}")
+            coords = cls._extract_intersection_coordinates(intersection)
+            if not coords:
+                continue
+
+            intersection_direction = get_average_straight_line(coords[0], coords[1])[1]
+            angle = cls._calculate_crossing_angle(intersection_direction, bridge.direction)
+            
+            if angle < cls.ANGLE_THRESHOLD:
+                logger.debug(f"{bridge.name} crossed, angle : {angle}")
                 crossed_bridges.append(bridge)
             else:
-                logger.info(f"{bridge.name} not crossed {angle}")
+                logger.debug(f"{bridge.name} not crossed, angle {angle}")
+
         return crossed_bridges
-
-    @staticmethod
-    def _calculate_length(geometry: BaseGeometry) -> float:
-        """Calculate total length of intersection geometry."""
-        if isinstance(geometry, GeometryCollection | MultiLineString):
-            return sum(geom.length for geom in geometry.geoms if isinstance(geom, LineString))
-        return geometry.length if isinstance(geometry, LineString) else 0
-
-    @staticmethod
-    def _get_median_line(geometry: BaseGeometry) -> tuple[float, float]:
-        """Calculate median line of intersection geometry."""
-        if isinstance(geometry, (GeometryCollection, MultiLineString)):
-            x_coords, y_coords = zip(*[coord for geom in geometry.geoms if isinstance(geom, LineString) 
-                                       for coord in geom.coords]) if geometry.geoms else ([], [])
-        elif isinstance(geometry, LineString):
-            x_coords, y_coords = geometry.xy
-        else:
-            return (1., 1.)
-        return get_average_straight_line(list(x_coords), list(y_coords))[1]
 
 @profile
 def prepare_download_city_bridges(query: OverpassQuery, track: GpxTrack) -> None:
     """Add the queries for city bridges inside the global OverpassQuery."""
-    cache_pkl = BRIDGES_CACHE.get_path(track)
-    if os.path.isfile(cache_pkl):
+    if os.path.isfile(cache_pkl := BRIDGES_CACHE.get_path(track)):
         query.add_cached_result(BRIDGES_CACHE.name, cache_file=cache_pkl)
         return
 
-    query.add_around_ways_overpass_query(array_name=BRIDGES_WAYS_ARRAY_NAME,
-                                         query_elements=['way["name"]["wikidata"]["man_made"="bridge"]',
-                                                         'way["name"]["bridge"~"(yes|aqueduct|cantilever|covered|movable|viaduct)"]'],
-                                         gpx_track=track,
-                                         relations=False,
-                                         radius_m=40)
+    query.add_around_ways_overpass_query(
+        array_name=BRIDGES_WAYS_ARRAY_NAME,
+        query_elements=['way["name"]["wikidata"]["man_made"="bridge"]',
+                        'way["name"]["bridge"~"(yes|aqueduct|cantilever|covered|movable|viaduct)"]'],
+        gpx_track=track,
+        relations=False,
+        radius_m=40)
 
-    query.add_around_ways_overpass_query(array_name=BRIDGES_RELATIONS_ARRAY_NAME,
-                                         query_elements=['relation["name"]["wikidata"]["man_made"="bridge"]'],
-                                         gpx_track=track,
-                                         relations=True,
-                                         radius_m=40)
+    query.add_around_ways_overpass_query(
+        array_name=BRIDGES_RELATIONS_ARRAY_NAME,
+        query_elements=['relation["name"]["wikidata"]["man_made"="bridge"]'],
+        gpx_track=track,
+        relations=True,
+        radius_m=40)
 
 @profile
 def process_city_bridges(query: OverpassQuery, track: GpxTrack) -> list[ScatterPoint]:
@@ -228,28 +230,29 @@ def process_city_bridges(query: OverpassQuery, track: GpxTrack) -> list[ScatterP
         return read_pickle(query.get_cache_file(BRIDGES_CACHE.name))
 
     with Profiling.Scope("Process Bridges"):
-        bridges_direction, bridges_stats, bridges_to_process = dict(), dict(), []
+        bridges_direction: dict[str, tuple[float, LineString]] = {}
+        bridges_stats = {}
+        bridges_to_process = []
+        
         for way in query.get_query_result(BRIDGES_WAYS_ARRAY_NAME).ways:
-            if way.tags.get("bridge", False) and way.tags.get("man_made", None) is None:
+            if way.tags.get("bridge") and "man_made" not in way.tags:
                 line = LineString(get_way_coordinates(way))
                 name = get_shortest_name(way)
-                if bridge_i := bridges_direction.get(name, False):
-                    if line.length > bridge_i[0]:
-                        bridges_direction[name] = (line.length, line)
-                else:
-                    bridges_direction[name] = (line.length, line)
-            if way.tags.get("man_made", None) is not None:
+                if name is None or name in bridges_direction and line.length <= bridges_direction[name][0]:
+                    continue
+                bridges_direction[name] = (line.length, line)
+            elif way.tags.get("man_made", False):
                 bridges_to_process.append(way)
 
-        for name, bridge in bridges_direction.items():
-            x_coords, y_coords = bridge[1].xy
-            line, direction = get_average_straight_line(x_coords, y_coords)
-            bridges_stats[name] = direction, line.length
+        bridges_stats = {
+            name: (get_average_straight_line(list(bridge[1].xy[0]), list(bridge[1].xy[1]))[1], bridge[1].length)
+            for name, bridge in bridges_direction.items()
+        }
 
         bridges = [BridgeApproximation.create_bridge(way, bridges_stats) for way in bridges_to_process]
-        logger.info(f"{len(bridges)} bridges")
-        bridges += [BridgeApproximation.create_bridge(rel, bridges_stats)
-                    for rel in query.get_query_result(BRIDGES_RELATIONS_ARRAY_NAME).relations]
+        bridges.extend(BridgeApproximation.create_bridge(rel, bridges_stats)
+                       for rel in query.get_query_result(BRIDGES_RELATIONS_ARRAY_NAME).relations)
+        
         crossed_bridges = BridgeCrossingAnalyzer.analyze_track_bridge_crossing(track, [b for b in bridges if b])
         result = [ScatterPoint(name=b.name, lat=b.center.y, lon=b.center.x, category=ScatterPointCategory.CITY_BRIDGE)
                   for b in crossed_bridges]

--- a/pretty_gpx/rendering_modes/city/data/bridges.py
+++ b/pretty_gpx/rendering_modes/city/data/bridges.py
@@ -1,54 +1,198 @@
 #!/usr/bin/python3
 """Bridges."""
 import os
+from dataclasses import dataclass
+
+import numpy as np
+from overpy import Relation
+from overpy import RelationWay
+from overpy import Way
+from shapely import oriented_envelope
+from shapely.geometry import GeometryCollection
+from shapely.geometry import LineString
+from shapely.geometry import MultiLineString
+from shapely.geometry import Point
+from shapely.geometry import Polygon as ShapelyPolygon
+from shapely.geometry.base import BaseGeometry
 
 from pretty_gpx.common.drawing.utils.scatter_point import ScatterPoint
 from pretty_gpx.common.drawing.utils.scatter_point import ScatterPointCategory
 from pretty_gpx.common.gpx.gpx_track import GpxTrack
 from pretty_gpx.common.request.gpx_data_cache_handler import GpxDataCacheHandler
-from pretty_gpx.common.request.overpass_processing import process_around_ways_and_relations
+from pretty_gpx.common.request.osm_name import get_shortest_name
+from pretty_gpx.common.request.overpass_processing import get_lat_lon_from_geometry
+from pretty_gpx.common.request.overpass_processing import get_way_coordinates
+from pretty_gpx.common.request.overpass_processing import merge_ways
 from pretty_gpx.common.request.overpass_request import OverpassQuery
 from pretty_gpx.common.utils.logger import logger
 from pretty_gpx.common.utils.pickle_io import read_pickle
 from pretty_gpx.common.utils.pickle_io import write_pickle
 from pretty_gpx.common.utils.profile import profile
 from pretty_gpx.common.utils.profile import Profiling
+from pretty_gpx.common.utils.utils import EARTH_RADIUS_M
 
 BRIDGES_CACHE = GpxDataCacheHandler(name='bridges', extension='.pkl')
 
-BRIDGES_ARRAY_NAME = "bridges"
+BRIDGES_RELATIONS_ARRAY_NAME = "bridges_relations"
+BRIDGES_WAYS_ARRAY_NAME = "bridges_ways"
 
+
+@dataclass
+class Bridge:
+    """Bridge."""
+    name: str | None
+    polygon: ShapelyPolygon
+    length: float
+    aspect_ratio: float
+    center: Point
+
+
+class BridgeApproximation:
+    """Bridge rectangle approximation."""
+    MAXIMUM_BRIDGE_ASPECT_RATIO = 0.75
+    MINIMUM_BRIDGE_ASPECT_RATIO = 0.1
+    MIN_BRIDGE_LENGTH_M = 40
+    MIN_BRIDGE_LENGTH = np.rad2deg(MIN_BRIDGE_LENGTH_M/EARTH_RADIUS_M)
+
+    @staticmethod
+    def get_minimum_rectangle(polygon: ShapelyPolygon,
+                              min_aspect_ratio: float = MINIMUM_BRIDGE_ASPECT_RATIO,
+                              min_length: float = MIN_BRIDGE_LENGTH) -> tuple[ShapelyPolygon | None, float, float]:
+        """Adjusts an oriented rectangle to meet a minimum aspect ratio by enlarging its width if necessary.
+
+        Args:
+            polygon: The shapely polygon of the bridge
+            min_aspect_ratio: The minimum allowed aspect ratio (width/length), defaults to 0.1
+            min_length: Minimum bridge length
+
+        Returns the adjusted rectangle as a Shapely Polygon, the final aspect ratio, the bridge length
+        """
+        if polygon.is_empty or polygon.area == 0:
+            raise ValueError("Input polygon is empty or degenerate.")
+
+        min_rot_rect = oriented_envelope(polygon)
+        if not hasattr(min_rot_rect, "exterior"):
+            raise ValueError("The minimum rotated rectangle does not have an exterior.")
+
+        rectangle = ShapelyPolygon(np.array(min_rot_rect.exterior.coords)) # type: ignore
+        coords = list(rectangle.exterior.coords[:-1])
+        sides = [(np.linalg.norm(np.array(coords[i]) - np.array(coords[(i + 1) % 4])),
+                  LineString([coords[i], coords[(i + 1) % 4]])) for i in range(4)]
+        sides.sort(key=lambda x: float(x[0]), reverse=True)
+        longest_length, shortest_length = float(sides[0][0]), float(sides[3][0])
+        aspect_ratio = shortest_length / longest_length
+
+        if (sides[0][0] + sides[1][0])/2.0 < min_length:
+            logger.warning("Bridge has not minimum length")
+            return None, 0., 0.
+
+        if aspect_ratio >= min_aspect_ratio:
+            return rectangle, aspect_ratio, longest_length
+
+        p1, p2 = sides[2][1].interpolate(0.5, normalized=True), sides[3][1].interpolate(0.5, normalized=True)
+        median_line = LineString([p1, p2])
+        buffer_size = float(longest_length * min_aspect_ratio) / 2.
+
+        return ShapelyPolygon(median_line.buffer(buffer_size)), min_aspect_ratio, longest_length
+
+    @classmethod
+    def create_bridge(cls, way_or_relation: Way | Relation) -> Bridge | None:
+        """Create a Bridge object from a way."""
+        try:
+            if isinstance(way_or_relation, Way):
+                bridge_coords = get_way_coordinates(way_or_relation)
+            elif isinstance(way_or_relation, Relation) and way_or_relation.members is not None:
+                outer_members = [
+                    member.geometry for member in way_or_relation.members
+                    if type(member) == RelationWay and member.geometry is not None and member.role == "outer"]
+
+                merged_ways = merge_ways(outer_members)
+                if len(merged_ways) > 1:
+                    logger.error("Multiple geometries found")
+                    return None
+                bridge_coords = get_lat_lon_from_geometry(merged_ways[0])
+            else:
+                raise TypeError   
+
+            bridge_polygon = ShapelyPolygon(bridge_coords)
+            bridge_simplified, aspect_ratio, longest_length = cls.get_minimum_rectangle(bridge_polygon)
+            bridge_name = get_shortest_name(way_or_relation)
+
+            if not bridge_simplified or aspect_ratio > cls.MAXIMUM_BRIDGE_ASPECT_RATIO:
+                logger.warning(f"Skipped bridge {bridge_name}: invalid aspect ratio or length.")
+                return None
+
+            return Bridge(name=bridge_name,
+                          polygon=bridge_simplified,
+                          length=longest_length,
+                          aspect_ratio=aspect_ratio,
+                          center=bridge_polygon.centroid)
+        except Exception as e:
+            logger.error(f"Error processing bridge: {e}")
+            return None
+
+class BridgeCrossingAnalyzer:
+    """Bridge and track intersection."""
+    INTERSECTION_THRESHOLD = 0.75
+
+    @staticmethod
+    def analyze_track_bridge_crossing(track: GpxTrack, bridges: list[Bridge]) -> list[Bridge]:
+        """Returns bridges significantly crossed by the track."""
+        crossed_bridges = []
+        shapely_track = LineString(list(zip(track.list_lon, track.list_lat)))
+
+        for bridge in bridges:
+            intersection = shapely_track.intersection(bridge.polygon)
+            if not intersection.is_empty:
+                intersection_length = BridgeCrossingAnalyzer._calculate_length(intersection)
+                if intersection_length > BridgeCrossingAnalyzer.INTERSECTION_THRESHOLD * bridge.length:
+                    logger.debug(f"{bridge.name} crossed")
+                    crossed_bridges.append(bridge)
+        return crossed_bridges
+
+    @staticmethod
+    def _calculate_length(geometry: BaseGeometry) -> float:
+        """Calculate total length of intersection geometry."""
+        if isinstance(geometry, GeometryCollection | MultiLineString):
+            return sum(geom.length for geom in geometry.geoms if isinstance(geom, LineString))
+        return geometry.length if isinstance(geometry, LineString) else 0
 
 @profile
 def prepare_download_city_bridges(query: OverpassQuery, track: GpxTrack) -> None:
     """Add the queries for city bridges inside the global OverpassQuery."""
     cache_pkl = BRIDGES_CACHE.get_path(track)
-
     if os.path.isfile(cache_pkl):
         query.add_cached_result(BRIDGES_CACHE.name, cache_file=cache_pkl)
         return
 
-    query.add_around_ways_overpass_query(array_name=BRIDGES_ARRAY_NAME,
-                                         query_elements=['wr["name"]["wikidata"]["man_made"="bridge"]'],
+    query.add_around_ways_overpass_query(array_name=BRIDGES_WAYS_ARRAY_NAME,
+                                         query_elements=['way["name"]["wikidata"]["man_made"="bridge"]'],
                                          gpx_track=track,
+                                         relations=False,
                                          radius_m=40)
 
+    query.add_around_ways_overpass_query(array_name=BRIDGES_RELATIONS_ARRAY_NAME,
+                                         query_elements=['relation["name"]["wikidata"]["man_made"="bridge"]'],
+                                         gpx_track=track,
+                                         relations=True,
+                                         radius_m=40)
 
 @profile
 def process_city_bridges(query: OverpassQuery, track: GpxTrack) -> list[ScatterPoint]:
     """Process the overpass API result to get the bridges of a city."""
     if query.is_cached(BRIDGES_CACHE.name):
-        cache_file = query.get_cache_file(BRIDGES_CACHE.name)
-        return read_pickle(cache_file)
+        return read_pickle(query.get_cache_file(BRIDGES_CACHE.name))
 
     with Profiling.Scope("Process Bridges"):
-        res = query.get_query_result(BRIDGES_ARRAY_NAME)
-        bridges = process_around_ways_and_relations(api_result=res)
-        bridges_l = [ScatterPoint(name=name, lat=lat, lon=lon, category=ScatterPointCategory.CITY_BRIDGE)
-                     for name, (lon, lat) in bridges.items()]
+        bridges = [BridgeApproximation.create_bridge(way)
+                   for way in query.get_query_result(BRIDGES_WAYS_ARRAY_NAME).ways]
+        bridges += [BridgeApproximation.create_bridge(rel)
+                    for rel in query.get_query_result(BRIDGES_RELATIONS_ARRAY_NAME).relations]
+        crossed_bridges = BridgeCrossingAnalyzer.analyze_track_bridge_crossing(track, [b for b in bridges if b])
+        result = [ScatterPoint(name=b.name, lat=b.center.y, lon=b.center.x, category=ScatterPointCategory.CITY_BRIDGE)
+                  for b in crossed_bridges]
 
-    logger.info(f"Found {len(bridges_l)} bridge(s)")
-    cache_pkl = BRIDGES_CACHE.get_path(track)
-    write_pickle(cache_pkl, bridges_l)
-    query.add_cached_result(BRIDGES_CACHE.name, cache_file=cache_pkl)
-    return bridges_l
+    logger.info(f"Found {len(result)} bridge(s)")
+    write_pickle(BRIDGES_CACHE.get_path(track), result)
+    query.add_cached_result(BRIDGES_CACHE.name, cache_file=BRIDGES_CACHE.get_path(track))
+    return result

--- a/pretty_gpx/test/test_bridges.py
+++ b/pretty_gpx/test/test_bridges.py
@@ -73,5 +73,4 @@ def test_bordeaux_bridges() -> None:
     """Test Bordeaux Bridges."""
     __core_test_bridges(os.path.join(RUNNING_DIR, "marathon_bordeaux.gpx"),
                         {"Pont de Pierre",
-                         "Pont Bacalan-Bastide"})
-    #The get_shortest_name function get Pont Bacalan-Bastide instead of Pont Jacques Chaban-Delmas
+                         "Pont Jacques Chaban-Delmas"})

--- a/pretty_gpx/test/test_bridges.py
+++ b/pretty_gpx/test/test_bridges.py
@@ -50,3 +50,28 @@ def test_new_york_bridges() -> None:
                          "Willis Avenue Bridge",
                          "Queensboro Bridge",
                          "Verrazzano-Narrows Bridge"})
+
+def test_berlin_bridges() -> None:
+    """Test Berlin Bridges."""
+    __core_test_bridges(os.path.join(RUNNING_DIR, "marathon_berlin.gpx"),
+                        {"Charlottenburger Brücke",
+                         "Kronprinzenbrücke",
+                         "Marchbrücke",
+                         "Gotzkowskybrücke",
+                         "Moltkebrücke",
+                         "Michaelbrücke",
+                         "Kottbusser Brücke",
+                         "Potsdamer Brücke"})
+
+def test_london_bridges() -> None:
+    """Test London Bridges."""
+    __core_test_bridges(os.path.join(RUNNING_DIR, "marathon_london.gpx"),
+                        {"Tower Bridge"})
+
+
+def test_bordeaux_bridges() -> None:
+    """Test Bordeaux Bridges."""
+    __core_test_bridges(os.path.join(RUNNING_DIR, "marathon_bordeaux.gpx"),
+                        {"Pont de Pierre",
+                         "Pont Bacalan-Bastide"})
+    #The get_shortest_name function get Pont Bacalan-Bastide instead of Pont Jacques Chaban-Delmas

--- a/pretty_gpx/test/test_bridges.py
+++ b/pretty_gpx/test/test_bridges.py
@@ -44,11 +44,9 @@ def test_paris_bridges() -> None:
 
 def test_new_york_bridges() -> None:
     """Test New York Bridges."""
-    # TODO: Fix the bridge extraction
-    # Current solution misses "Verrazzano-Narrows Bridge" and incorrectly includes "RFK Bridge"
     __core_test_bridges(os.path.join(RUNNING_DIR, "marathon_new_york.gpx"),
-                        {"RFK Bridge",
-                         "Madison Avenue Bridge",
+                        {"Madison Avenue Bridge",
                          "Pulaski Bridge",
                          "Willis Avenue Bridge",
-                         "Queensboro Bridge"})
+                         "Queensboro Bridge",
+                         "Verrazzano-Narrows Bridge"})


### PR DESCRIPTION
## Description

Relation processing was intended for rivers and not for farmland/other types. Add a passthrough, if strange behavior occurs, might need to work a bit more on this.


Bridges are handled correctly with ways and relations. 
Additionnaly, to check that the bridges are crossed by the track, 2 tests are done : the length of the intersection and the direction of the intersection vs the direction of the bridge.
This approach seems robusts. The only inconvenient is that we need to have the same name for ways/roads and bridge area (ways/relations) in order the get 2 alignments to comparer to each other. 

https://github.com/ThomasParistech/pretty-gpx/issues/83