### PR TITLE
fix: Mountain drawer - fix end city name+pos

### DIFF
--- a/pretty_gpx/common/data/place_name.py
+++ b/pretty_gpx/common/data/place_name.py
@@ -47,15 +47,20 @@ def get_start_end_named_points(gpx_track: GpxTrack | MultiGpxTrack) -> list[Scat
                          lon=start_lon,
                          lat=start_lat,
                          category=ScatterPointCategory.START)
-    end = ScatterPoint(name=get_place_name(lon=end_lon, lat=end_lat),
-                       lon=end_lon,
-                       lat=end_lat,
-                       category=ScatterPointCategory.END)
 
     if get_distance_m(lonlat_1=(start_lon, start_lat),
                       lonlat_2=(end_lon, end_lat)) < 1000:
+        # Start and end are too close, skip name and position of end point
+        end = ScatterPoint(name=None,
+                           lon=start_lon,
+                           lat=start_lat,
+                           category=ScatterPointCategory.END)
+    else:
+        # Start and end are far enough, keep name of end point only if different from start
         name = get_place_name(lon=end_lon, lat=end_lat)
-        if name != start.name:
-            end.name = name
+        end = ScatterPoint(name=name if name != start.name else None,
+                           lon=end_lon,
+                           lat=end_lat,
+                           category=ScatterPointCategory.END)
 
     return [start, end]

--- a/pretty_gpx/common/data/place_name.py
+++ b/pretty_gpx/common/data/place_name.py
@@ -47,9 +47,9 @@ def get_start_end_named_points(gpx_track: GpxTrack | MultiGpxTrack) -> list[Scat
                          lon=start_lon,
                          lat=start_lat,
                          category=ScatterPointCategory.START)
-    end = ScatterPoint(name=None,
-                       lon=start_lon,
-                       lat=start_lat,
+    end = ScatterPoint(name=get_place_name(lon=end_lon, lat=end_lat),
+                       lon=end_lon,
+                       lat=end_lat,
                        category=ScatterPointCategory.END)
 
     if get_distance_m(lonlat_1=(start_lon, start_lat),

--- a/pretty_gpx/test/test_start_end_names.py
+++ b/pretty_gpx/test/test_start_end_names.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+"""Test Start/End names."""
+
+import os
+
+from pretty_gpx.common.data.place_name import get_start_end_named_points
+from pretty_gpx.common.gpx.gpx_track import GpxTrack
+from pretty_gpx.common.utils.asserts import assert_eq
+from pretty_gpx.common.utils.paths import CYCLING_DIR
+from pretty_gpx.common.utils.paths import HIKING_DIR
+
+
+def __core_test_start_end_names(path: str, gt_start_name: str, gt_end_name: str | None) -> None:
+    """Test Start/End names."""
+    # GIVEN
+    gpx = GpxTrack.load(path)
+
+    # WHEN
+    start, end = get_start_end_named_points(gpx)
+
+    # THEN
+    assert_eq(start.name, gt_start_name)
+    assert_eq(end.name, gt_end_name)
+
+
+def test_vanoise_3() -> None:
+    """Test Vanoise 3."""
+    __core_test_start_end_names(os.path.join(HIKING_DIR, "vanoise3.gpx"),
+                                gt_start_name="Aussois",
+                                gt_end_name="Pralognan-la-Vanoise")
+
+
+def test_vanoise() -> None:
+    """Test Vanoise."""
+    __core_test_start_end_names(os.path.join(HIKING_DIR, "vanoise.gpx"),
+                                gt_start_name="Pralognan-la-Vanoise",
+                                gt_end_name=None)  # Loop
+
+
+def test_marmotte() -> None:
+    """Test Marmotte."""
+    __core_test_start_end_names(os.path.join(CYCLING_DIR, "marmotte.gpx"),
+                                gt_start_name="Le Bourg-d'Oisans",
+                                gt_end_name="L'Alpe d'Huez")


### PR DESCRIPTION
## Description
I was playing around with the mountain drawer (single GPX file) and I couldn't get the name of the last city to appear on the final image. Going through the code I found this small change to register the end point with the correct name and position by leveraging the GPX data and the existing `get_place_name` function.

I did not exhaustively QA these changes but it appears to be working as expected.

## Proof of Functionality
Before: 
![image](https://github.com/user-attachments/assets/0760071e-885c-4fa8-8602-4e7b7a52317b)

After:
![image](https://github.com/user-attachments/assets/34174f89-db7c-4a8b-97ee-cf532deff047)
