### PR TITLE
feat: Handle flat elevation profiles

### DIFF
--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -20,4 +20,4 @@ textalloc==1.1.6
 shapely==2.0.6
 types-shapely==2.0.0.20241221
 orjson==3.10.7
-requests==2.32.3
+requests==2.32.4

--- a/pretty_gpx/common/drawing/components/elevation_profile.py
+++ b/pretty_gpx/common/drawing/components/elevation_profile.py
@@ -18,10 +18,49 @@ from pretty_gpx.common.drawing.utils.scatter_point import ScatterPointCategory
 from pretty_gpx.common.gpx.gpx_bounds import GpxBounds
 from pretty_gpx.common.gpx.gpx_distance import get_pairwise_distance_m
 from pretty_gpx.common.gpx.gpx_track import GpxTrack
+from pretty_gpx.common.gpx.multi_gpx_track import MultiGpxTrack
 from pretty_gpx.common.layout.paper_size import PaperSize
 from pretty_gpx.common.utils.asserts import assert_in
 from pretty_gpx.common.utils.asserts import assert_same_len
 from pretty_gpx.common.utils.utils import get
+
+
+def handle_flat_elevation_profile(track: GpxTrack | MultiGpxTrack,
+                                  bot_ratio: float,
+                                  ele_ratio: float) -> tuple[float, float]:
+    """For nearly flat tracks with gradients below 1%, reduce vertical scaling accordingly.
+
+    1  ┌───────────────────────x────────────┐   ▲     
+       │                    xxxxxxx         │   │   ele_ratio
+       │  xxxxxxxxxxx    xxxx     xxxxxxxxxx│   │    
+       xxx          xxxxxx                 xx   ▼    
+       x                                    x       
+       x                                    x       
+       x                                    x      
+       x                                    x    
+       x                                    x     
+    0  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  1     
+    """
+    if isinstance(track, GpxTrack):
+        uphill_m = track.uphill_m
+        dist_km = track.dist_km
+    else:
+        uphill_m = sum(t.uphill_m for t in track.tracks)
+        dist_km = sum(t.dist_km for t in track.tracks)
+
+    avg_gradient = uphill_m*1e-3/dist_km
+    ref_gradient = 0.01  # 1%
+
+    if 0 <= avg_gradient < ref_gradient:
+        downscale = avg_gradient / ref_gradient
+
+        new_total_height = 1.0 - ele_ratio*(1.-downscale)
+        new_ele_height = ele_ratio * downscale
+
+        bot_ratio *= new_total_height
+        ele_ratio = new_ele_height / new_total_height
+
+    return bot_ratio, ele_ratio
 
 
 def downsample(x: np.ndarray, y: np.ndarray, n: int) -> tuple[np.ndarray, np.ndarray]:
@@ -86,10 +125,6 @@ class ElevationProfile:
         # Draw Elevation Over Distance
         normalized_poly_lon = np.array(track.list_cumul_dist_km)/track.list_cumul_dist_km[-1]  # in [0, 1]
         min_ele, max_ele = min(track.list_ele_m), max(track.list_ele_m)
-
-        avg_gradient = track.uphill_m*1e-3/track.list_cumul_dist_km[-1]
-        if avg_gradient < 1e-2:
-            ele_ratio = ele_ratio/(1e-2/avg_gradient if avg_gradient > 0 else 1e2)
 
         normalized_poly_lat = (np.array(track.list_ele_m) - min_ele) / (max_ele - min_ele)  # in [0, 1]
 

--- a/pretty_gpx/common/drawing/components/elevation_profile.py
+++ b/pretty_gpx/common/drawing/components/elevation_profile.py
@@ -125,7 +125,6 @@ class ElevationProfile:
         # Draw Elevation Over Distance
         normalized_poly_lon = np.array(track.list_cumul_dist_km)/track.list_cumul_dist_km[-1]  # in [0, 1]
         min_ele, max_ele = min(track.list_ele_m), max(track.list_ele_m)
-
         normalized_poly_lat = (np.array(track.list_ele_m) - min_ele) / (max_ele - min_ele)  # in [0, 1]
 
         rel_poly_lat = (1.0-ele_ratio) + ele_ratio * normalized_poly_lat

--- a/pretty_gpx/common/drawing/components/elevation_profile.py
+++ b/pretty_gpx/common/drawing/components/elevation_profile.py
@@ -86,6 +86,11 @@ class ElevationProfile:
         # Draw Elevation Over Distance
         normalized_poly_lon = np.array(track.list_cumul_dist_km)/track.list_cumul_dist_km[-1]  # in [0, 1]
         min_ele, max_ele = min(track.list_ele_m), max(track.list_ele_m)
+
+        avg_gradient = track.uphill_m*1e-3/track.list_cumul_dist_km[-1]
+        if avg_gradient < 1e-2:
+            ele_ratio = ele_ratio/(1e-2/avg_gradient if avg_gradient > 0 else 1e2)
+
         normalized_poly_lat = (np.array(track.list_ele_m) - min_ele) / (max_ele - min_ele)  # in [0, 1]
 
         rel_poly_lat = (1.0-ele_ratio) + ele_ratio * normalized_poly_lat

--- a/pretty_gpx/common/layout/vertical_layout.py
+++ b/pretty_gpx/common/layout/vertical_layout.py
@@ -118,7 +118,7 @@ class VerticalLayoutUnion:
                    *,
                    top_ratio: float,
                    bot_ratio: float,
-                   margin_ratio: float,) -> 'VerticalLayoutUnion':
+                   margin_ratio: float) -> 'VerticalLayoutUnion':
         """Store the Vertical Layouts for different Paper Sizes and take the union of the Background Bounds."""
         layouts = {paper: VerticalLayout.from_track(gpx_track, paper, top_ratio, bot_ratio, margin_ratio)
                    for paper in PAPER_SIZES.values()}

--- a/pretty_gpx/common/layout/vertical_layout.py
+++ b/pretty_gpx/common/layout/vertical_layout.py
@@ -118,7 +118,7 @@ class VerticalLayoutUnion:
                    *,
                    top_ratio: float,
                    bot_ratio: float,
-                   margin_ratio: float) -> 'VerticalLayoutUnion':
+                   margin_ratio: float,) -> 'VerticalLayoutUnion':
         """Store the Vertical Layouts for different Paper Sizes and take the union of the Background Bounds."""
         layouts = {paper: VerticalLayout.from_track(gpx_track, paper, top_ratio, bot_ratio, margin_ratio)
                    for paper in PAPER_SIZES.values()}

--- a/pretty_gpx/rendering_modes/city/drawing/city_drawer.py
+++ b/pretty_gpx/rendering_modes/city/drawing/city_drawer.py
@@ -9,6 +9,7 @@ from pretty_gpx.common.data.place_name import get_start_end_named_points
 from pretty_gpx.common.drawing.components.annotated_scatter import AnnotatedScatterAll
 from pretty_gpx.common.drawing.components.centered_title import CenteredTitle
 from pretty_gpx.common.drawing.components.elevation_profile import ElevationProfile
+from pretty_gpx.common.drawing.components.elevation_profile import handle_flat_elevation_profile
 from pretty_gpx.common.drawing.components.track_data import TrackData
 from pretty_gpx.common.drawing.utils.drawer import DrawerSingleTrack
 from pretty_gpx.common.drawing.utils.drawing_figure import DrawingFigure
@@ -53,9 +54,12 @@ class CityDrawer(DrawerSingleTrack):
     def change_gpx(self, gpx_path: str | bytes, paper: PaperSize) -> None:
         """Load a single GPX file to create a City Poster."""
         gpx_track = GpxTrack.load(gpx_path)
+        ele_ratio = 0.45
+        bot_ratio, ele_ratio = handle_flat_elevation_profile(gpx_track, self.bot_ratio, ele_ratio)
+
         layouts = VerticalLayoutUnion.from_track(gpx_track,
                                                  top_ratio=self.top_ratio,
-                                                 bot_ratio=self.bot_ratio,
+                                                 bot_ratio=bot_ratio,
                                                  margin_ratio=self.margin_ratio)
 
         total_query = OverpassQuery()
@@ -72,7 +76,7 @@ class CityDrawer(DrawerSingleTrack):
 
         layout = layouts.layouts[paper]
         background.change_papersize(paper, layout.background_bounds)
-        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=0.45)
+        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=ele_ratio)
         title = CenteredTitle(bounds=layout.top_bounds)
         scatter_all = AnnotatedScatterAll.from_scatter(paper, layout.background_bounds, layout.mid_bounds,
                                                        scatter_points, self.params)

--- a/pretty_gpx/rendering_modes/city/drawing/city_drawer.py
+++ b/pretty_gpx/rendering_modes/city/drawing/city_drawer.py
@@ -72,7 +72,7 @@ class CityDrawer(DrawerSingleTrack):
 
         layout = layouts.layouts[paper]
         background.change_papersize(paper, layout.background_bounds)
-        ele_pofile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=0.45)
+        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=0.45)
         title = CenteredTitle(bounds=layout.top_bounds)
         scatter_all = AnnotatedScatterAll.from_scatter(paper, layout.background_bounds, layout.mid_bounds,
                                                        scatter_points, self.params)
@@ -80,7 +80,7 @@ class CityDrawer(DrawerSingleTrack):
 
         self.data = CityLayout(layouts=layouts,
                                background=background,
-                               bot=ele_pofile,
+                               bot=ele_profile,
                                top=title,
                                mid_scatter=scatter_all,
                                mid_track=track_data,

--- a/pretty_gpx/rendering_modes/mountain/drawing/mountain_drawer.py
+++ b/pretty_gpx/rendering_modes/mountain/drawing/mountain_drawer.py
@@ -66,7 +66,7 @@ class MountainDrawer(DrawerSingleTrack):
 
         layout = layouts.layouts[paper]
         background.change_papersize(paper, layout.background_bounds)
-        ele_pofile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=0.45)
+        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=0.45)
         title = CenteredTitle(bounds=layout.top_bounds)
         scatter_all = AnnotatedScatterAll.from_scatter(paper, layout.background_bounds, layout.mid_bounds,
                                                        scatter_points, self.params)
@@ -74,7 +74,7 @@ class MountainDrawer(DrawerSingleTrack):
 
         self.data = MountainLayout(layouts=layouts,
                                    background=background,
-                                   bot=ele_pofile,
+                                   bot=ele_profile,
                                    top=title,
                                    mid_scatter=scatter_all,
                                    mid_track=track_data,

--- a/pretty_gpx/rendering_modes/mountain/drawing/mountain_drawer.py
+++ b/pretty_gpx/rendering_modes/mountain/drawing/mountain_drawer.py
@@ -9,6 +9,7 @@ from pretty_gpx.common.data.place_name import get_start_end_named_points
 from pretty_gpx.common.drawing.components.annotated_scatter import AnnotatedScatterAll
 from pretty_gpx.common.drawing.components.centered_title import CenteredTitle
 from pretty_gpx.common.drawing.components.elevation_profile import ElevationProfile
+from pretty_gpx.common.drawing.components.elevation_profile import handle_flat_elevation_profile
 from pretty_gpx.common.drawing.components.track_data import TrackData
 from pretty_gpx.common.drawing.utils.drawer import DrawerSingleTrack
 from pretty_gpx.common.drawing.utils.drawing_figure import DrawingFigure
@@ -51,9 +52,12 @@ class MountainDrawer(DrawerSingleTrack):
     def change_gpx(self, gpx_path: str | bytes, paper: PaperSize) -> None:
         """Load a single GPX file to create a Mountain Poster."""
         gpx_track = GpxTrack.load(gpx_path)
+        ele_ratio = 0.45
+        bot_ratio, ele_ratio = handle_flat_elevation_profile(gpx_track, self.bot_ratio, ele_ratio)
+
         layouts = VerticalLayoutUnion.from_track(gpx_track,
                                                  top_ratio=self.top_ratio,
-                                                 bot_ratio=self.bot_ratio,
+                                                 bot_ratio=bot_ratio,
                                                  margin_ratio=self.margin_ratio)
 
         total_query = OverpassQuery()
@@ -66,7 +70,7 @@ class MountainDrawer(DrawerSingleTrack):
 
         layout = layouts.layouts[paper]
         background.change_papersize(paper, layout.background_bounds)
-        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=0.45)
+        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track, scatter_points, ele_ratio=ele_ratio)
         title = CenteredTitle(bounds=layout.top_bounds)
         scatter_all = AnnotatedScatterAll.from_scatter(paper, layout.background_bounds, layout.mid_bounds,
                                                        scatter_points, self.params)

--- a/pretty_gpx/rendering_modes/multi_mountain/drawing/multi_mountain_drawer.py
+++ b/pretty_gpx/rendering_modes/multi_mountain/drawing/multi_mountain_drawer.py
@@ -66,7 +66,7 @@ class MultiMountainDrawer(DrawerMultiTrack):
 
         layout = layouts.layouts[paper]
         background.change_papersize(paper, layout.background_bounds)
-        ele_pofile = ElevationProfile.from_track(layout.bot_bounds, gpx_track.merge(), scatter_points, ele_ratio=0.45)
+        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track.merge(), scatter_points, ele_ratio=0.45)
         title = CenteredTitle(bounds=layout.top_bounds)
         scatter_all = AnnotatedScatterAll.from_scatter(paper, layout.background_bounds, layout.mid_bounds,
                                                        scatter_points, self.params)
@@ -74,7 +74,7 @@ class MultiMountainDrawer(DrawerMultiTrack):
 
         self.data = MultiMountainLayout(layouts=layouts,
                                         background=background,
-                                        bot=ele_pofile,
+                                        bot=ele_profile,
                                         top=title,
                                         mid_scatter=scatter_all,
                                         mid_track=track_data,

--- a/pretty_gpx/rendering_modes/multi_mountain/drawing/multi_mountain_drawer.py
+++ b/pretty_gpx/rendering_modes/multi_mountain/drawing/multi_mountain_drawer.py
@@ -9,6 +9,7 @@ from pretty_gpx.common.data.place_name import get_start_end_named_points
 from pretty_gpx.common.drawing.components.annotated_scatter import AnnotatedScatterAll
 from pretty_gpx.common.drawing.components.centered_title import CenteredTitle
 from pretty_gpx.common.drawing.components.elevation_profile import ElevationProfile
+from pretty_gpx.common.drawing.components.elevation_profile import handle_flat_elevation_profile
 from pretty_gpx.common.drawing.components.track_data import TrackData
 from pretty_gpx.common.drawing.utils.drawer import DrawerMultiTrack
 from pretty_gpx.common.drawing.utils.drawing_figure import DrawingFigure
@@ -51,9 +52,12 @@ class MultiMountainDrawer(DrawerMultiTrack):
     def change_gpx(self, gpx_paths: list[str] | list[bytes], paper: PaperSize) -> None:
         """Load several GPX file to create a Multi Mountain Poster."""
         gpx_track = MultiGpxTrack.load(gpx_paths)
+        ele_ratio = 0.45
+        bot_ratio, ele_ratio = handle_flat_elevation_profile(gpx_track, self.bot_ratio, ele_ratio)
+
         layouts = VerticalLayoutUnion.from_track(gpx_track,
                                                  top_ratio=self.top_ratio,
-                                                 bot_ratio=self.bot_ratio,
+                                                 bot_ratio=bot_ratio,
                                                  margin_ratio=self.margin_ratio)
 
         total_query = OverpassQuery()
@@ -66,7 +70,8 @@ class MultiMountainDrawer(DrawerMultiTrack):
 
         layout = layouts.layouts[paper]
         background.change_papersize(paper, layout.background_bounds)
-        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track.merge(), scatter_points, ele_ratio=0.45)
+        ele_profile = ElevationProfile.from_track(layout.bot_bounds, gpx_track.merge(), scatter_points,
+                                                  ele_ratio=ele_ratio)
         title = CenteredTitle(bounds=layout.top_bounds)
         scatter_all = AnnotatedScatterAll.from_scatter(paper, layout.background_bounds, layout.mid_bounds,
                                                        scatter_points, self.params)


### PR DESCRIPTION
## Description
Built upon idea of @JulesL2 to handle tracks with flat elevation profiles.
Instead of modifying at drawing time, I update the bot_ratio and ele_ratio accordingly right before downloading the background data. That way we end up with a perflectly centered background, instead of leaving some kind of empty space above the flattened elevation profile.

## Corresponding Github Issues / Pull Requests
PR https://github.com/ThomasParistech/pretty-gpx/pull/97
Issue https://github.com/ThomasParistech/pretty-gpx/issues/93

## Proof of Functionality
*Provide evidence that the changes work as intended. Include screenshots, logs, or other relevant output.*
Left: Current main branch. The elevation profile is excessively large compared to the low total uphill
Right: Proposed solution. The background has been slightly shifted towards the bottom
<img width="1203" height="874" alt="image" src="https://github.com/user-attachments/assets/d58ca490-d59a-49eb-ae99-7da0286810e1" />

## Warning